### PR TITLE
Add support for two letter ISO-639-1 language codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ cimpress-translations is a convenient client for Cimpress' Translations service.
 
 Features:
 - list and describe services; modify a service structure; get and put language blobs for a language
-- pick language using ISO-639-2 ('eng', 'fra') or by passing the language's English name ('English', 'French')
+- pick language using ISO-639-2 ('eng', 'fra') or ISO-639-1 ('en', 'fr') or by passing the language's English name ('English', 'French')
 - supply authorization statically (using a hard-coded string) or dynamically (with a custom method)
 - convenience of a default service URL with the possibility of an override
 
@@ -55,7 +55,7 @@ console.log(service);
 ```
 
 ##### client.getLanguageBlob(serviceId, language)
-Retrieves the translation for a service in a given language. The language may be specified using ISO-639-2 ('eng', 'fra') or selected using its English name ('English', 'French').
+Retrieves the translation for a service in a given language. The language may be specified using ISO-639-2 ('eng', 'fra') or ISO-639-1 ('en', 'fr') or selected using its English name ('English', 'French').
 ```javascript
 let services = await client.getLanguageBlob("28b1f0d2-9366-40cb-95bd-14de8c3adb9b", "French");
 console.log(service);

--- a/__tests__/language.test.js
+++ b/__tests__/language.test.js
@@ -25,6 +25,21 @@ describe("for language utility module", () => {
       });
     });
 
+    it("returns ISO 639-2 code of language given ISO 639-1 code", () => {
+      let testLanguages = {
+        "en": "eng",
+        "fr": "fra",
+        "de": "deu",
+        "nl": "nld",
+        "sk": "slk",
+        "tr": "tur"
+      };
+
+      Object.entries(testLanguages).map(l => {
+        assert.equal(language.findLanguageCode(l[0]), l[1]);
+      });
+    });
+
     it("returns ISO 639-2 code of language given English name of language", () => {
       let testLanguages = {
         "English": "eng",

--- a/src/language.js
+++ b/src/language.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { iso_639_2 } = require("iso-639");
+const { iso_639_1, iso_639_2 } = require("iso-639");
 
 const getLanguageCodeFromEnglishName = language => {
   let foundLanguage = Object.values(iso_639_2).find(entry => entry.en
@@ -10,8 +10,9 @@ const getLanguageCodeFromEnglishName = language => {
 };
 
 const findLanguageCode = language => {
-  let languageByCode = (iso_639_2[language] || {})["639-2"];
-  return languageByCode || getLanguageCodeFromEnglishName(language) || null;
+  let languageByThreeLetterCode = (iso_639_2[language] || {})["639-2"];
+  let languageByTwoLetterCode = (iso_639_1[language] || {})["639-2"];
+  return languageByThreeLetterCode || languageByTwoLetterCode || getLanguageCodeFromEnglishName(language) || null;
 };
 
 const findLanguage = language => {


### PR DESCRIPTION
Some other Cimpress related tools as Customizr work with two-letter ISO-639-1 language codes. Therefore adding support to this client removes the need to re-implement this mapping logic.